### PR TITLE
Fix projectcard array check

### DIFF
--- a/src/components/projectcard.js
+++ b/src/components/projectcard.js
@@ -2,6 +2,10 @@
 import getData from '@/components/api/getData'
 export default async function ProjectCard(){
     let projects = await getData('api/project/')
+    if(!Array.isArray(projects)){
+        console.error('Project data is not an array')
+        projects = []
+    }
     return (
         <section className='card'>
             <h3>Project Contributions</h3>


### PR DESCRIPTION
## Summary
- handle data that isn't an array when listing project contributions

## Testing
- `npm run lint` *(fails: next not found)*