### PR TITLE
Fix telephone contact link

### DIFF
--- a/src/components/contactinfolist.js
+++ b/src/components/contactinfolist.js
@@ -4,7 +4,7 @@ export default function ContactInfoList(){
     return (
         <ul>
             <li key="phoneNumber">
-                <a href='Tel:7329080037'>
+                <a href='tel:7329080037'>
                     <FontAwesomeIcon icon={faPhone}/>
                     &nbsp;+1(732)-908-0037
                 </a>


### PR DESCRIPTION
## Summary
- ensure telephone link uses lowercase `tel:` scheme

## Testing
- `npm run lint` *(fails: `next: not found`)*