### PR TITLE
Fix trailing comment in page.js

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -27,4 +27,3 @@ export default function Page(){
         </>
     )
 }
-//


### PR DESCRIPTION
## Summary
- remove stray comment from `src/app/page.js`

## Testing
- `node -e "require('fs').readFileSync('src/app/page.js','utf8')"`