### PR TITLE
Move theme toggle outside navigation

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -7,6 +7,7 @@ import FullResumeState from '@/components/providers/fullresumestate'
 import PostBrowserProvider from '@/components/providers/postbrowserstate'
 import PostBrowser from '@/components/postbrowser/postbrowser'
 import AIAssistant from '@/components/AIAssistant'
+import ThemeToggle from '@/components/themeToggle'
 import '@/styles/style.sass'
 import { config } from '@fortawesome/fontawesome-svg-core'
 import '@fortawesome/fontawesome-svg-core/styles.css'
@@ -14,6 +15,9 @@ config.autoAddCss = false;
 export default function Page(){
     return (
         <>
+            <div className='page-theme-toggle'>
+                <ThemeToggle/>
+            </div>
             <Nav/>
             <Header/>
             <PostBrowserProvider>

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -1,7 +1,6 @@
 'use client'
 import Logo from '@/images/logo'
 import NavList from './navlist'
-import ThemeToggle from './themeToggle'
 import Chevron from '@/images/chevron.svg'
 import Image from 'next/image'
 import {useState} from 'react'
@@ -20,9 +19,6 @@ export default function Nav(){
     }
     return (
         <nav className='Nav'>
-            <section className='nav-theme-toggle'>
-                <ThemeToggle/>
-            </section>
             <section>
                 <section className='menu-logo-container'>
                     <Logo/>

--- a/src/styles/partials/_base.sass
+++ b/src/styles/partials/_base.sass
@@ -89,3 +89,9 @@ li
     font-family: variables.$secondary-font
     font-size: 18px
     font-weight: 400
+
+.page-theme-toggle
+    position: fixed
+    top: variables.$margin
+    right: variables.$margin
+    z-index: 3

--- a/src/styles/partials/_navigation.sass
+++ b/src/styles/partials/_navigation.sass
@@ -7,10 +7,6 @@ nav.Nav
     background-color: variables.$primary-dark-blue
     box-shadow: variables.$shadow
     z-index: 2
-    .nav-theme-toggle
-        position: absolute
-        top: variables.$margin
-        right: variables.$margin
     > section
         display: grid
         grid-template-areas: "logo menu" "list list"


### PR DESCRIPTION
## Summary
- remove ThemeToggle from nav
- show ThemeToggle in a new fixed position
- style page-theme-toggle container

## Testing
- `npx next lint` *(fails: connect EHOSTUNREACH)*