### PR TITLE
Fix text shadow in dark mode

### DIFF
--- a/src/styles/partials/_responsive.sass
+++ b/src/styles/partials/_responsive.sass
@@ -129,3 +129,7 @@ img
             width: variables.$post-width-xl
         iframe
             height: variables.$post-iframe-height-xl
+
+// Disable text shadow in dark mode for readability
+[data-theme='dark'], [data-theme='dark'] *
+    text-shadow: none


### PR DESCRIPTION
## Summary
- remove text shadows when the site is in dark mode

## Testing
- `npm run lint` *(fails: `next` not found)*