### PR TITLE
Fix toggleDrawer signature

### DIFF
--- a/src/components/providers/fullresumestate.js
+++ b/src/components/providers/fullresumestate.js
@@ -10,7 +10,7 @@ export default function FullResumeState({children}){
         </FullResumeStateContext.Provider>
     )
 }
-function toggleDrawer(previousState, {command}){
+function toggleDrawer(previousState){
     switch (previousState) {
         case 'open':
             return 'opened'


### PR DESCRIPTION
## Summary
- remove unused `{command}` parameter from the `toggleDrawer` reducer

## Testing
- `npm run lint` *(fails: next not found)*