### PR TITLE
Refactor modal state handling

### DIFF
--- a/src/components/providers/fullresumestate.js
+++ b/src/components/providers/fullresumestate.js
@@ -1,25 +1,14 @@
 "use client"
-import {useContext, createContext, useReducer} from 'react'
+import {useContext, createContext} from 'react'
+import useToggleCycle from './useToggleCycle'
 const FullResumeStateContext = createContext()
 export default function FullResumeState({children}){
-    const [display, toggleDisplay] = useReducer(toggleDrawer,'closed')
+    const [display, toggleDisplay] = useToggleCycle('closed')
     
     return (
         <FullResumeStateContext.Provider value={{display, toggleDisplay}}>
             {children}
         </FullResumeStateContext.Provider>
     )
-}
-function toggleDrawer(previousState, {command}){
-    switch (previousState) {
-        case 'open':
-            return 'opened'
-        case 'opened':
-            return 'close'
-        case 'close':
-            return 'closed'
-        case 'closed':
-            return 'open'
-    }
 }
 export const ResumeState = () => useContext(FullResumeStateContext)

--- a/src/components/providers/postbrowserstate.js
+++ b/src/components/providers/postbrowserstate.js
@@ -1,20 +1,9 @@
 "use client"
-import {createContext, useContext, useReducer} from 'react'
+import {createContext, useContext} from 'react'
+import useToggleCycle from './useToggleCycle'
 const PostBrowserContext = createContext()
-export function displayReducer(previousState, args){
-    switch(previousState){
-        case 'open':
-            return 'opened'
-        case 'opened':
-            return 'close'
-        case 'close':
-            return 'closed'
-        default:
-            return 'open'
-    }
-}
 export default function PostBrowserProvider({children}){
-    const [display, toggleDisplay] = useReducer(displayReducer, '')
+    const [display, toggleDisplay] = useToggleCycle('closed')
     return (
         <PostBrowserContext.Provider value={{display, toggleDisplay}}>
             {children}

--- a/src/components/providers/useToggleCycle.js
+++ b/src/components/providers/useToggleCycle.js
@@ -1,0 +1,20 @@
+"use client"
+import { useReducer } from 'react'
+
+export function toggleCycleReducer(previousState){
+    switch(previousState){
+        case 'open':
+            return 'opened'
+        case 'opened':
+            return 'close'
+        case 'close':
+            return 'closed'
+        case 'closed':
+        default:
+            return 'open'
+    }
+}
+
+export default function useToggleCycle(initialState = 'closed'){
+    return useReducer(toggleCycleReducer, initialState)
+}

--- a/src/styles/partials/_modals.sass
+++ b/src/styles/partials/_modals.sass
@@ -3,33 +3,37 @@
 // Modal and popup styles
 // Full Resume Modal
 section#fullResume
-    display: none
     position: fixed
-    flex-flow: column
-    align-items: center
-    z-index: 3
     width: 100vw
-    height: calc(100vh - variables.$margin-double)
-    top: 0
-    background-color: #00000044
+    height: 100vh
+    background-color: #00000040
     color: variables.$primary-dark-blue
     text-shadow: variables.$shadow
-    
+    display: none
+    flex-flow: column nowrap
+    justify-content: center
+    align-items: center
+    z-index: 3
+    animation: none
+
     > article
         position: relative
         display: flex
-        flex-flow: column nowrap
+        height: 100vh
         overflow-y: scroll
+        flex-flow: column nowrap
         background-color: variables.$highlight-offwhite
-        box-shadow: variables.$shadow
+        width: calc(100% - variables.$margin-double)
         padding: variables.$margin
+        box-shadow: variables.$shadow
+        animation: none
         h1, hr
             margin-bottom: variables.$margin-half
-    
+
     p
         margin: 0
         max-width: 100%
-    
+
     li
         font-family: variables.$secondary-font
         font-size: 18px
@@ -40,22 +44,29 @@ section#fullResume
 section#fullResume
     &.open
         display: flex
-        animation: slide-in-up 0.25s ease
-        animation-fill-mode: backwards
-        animation-delay: 0.45s
-    
+        > article
+            animation: slide-in-up 0.25s ease
+            animation-fill-mode: forwards
+
     &.opened
         display: flex
         animation: none
-    
+        > article
+            animation: none
+
     &.close
         display: flex
-        animation: slide-in-up 0.25s ease reverse
+        animation: slide-in-up 0s 0.25s reverse
         animation-fill-mode: forwards
-    
+        > article
+            animation: slide-in-up 0.25s 0s ease reverse
+            animation-fill-mode: forwards
+
     &.closed
         display: none
         animation: none
+        > article
+            animation: none
 
 // Close button
 button.CloseButton


### PR DESCRIPTION
## Summary
- add `useToggleCycle` hook for modal state
- refactor `FullResumeState` and `PostBrowserProvider` to use the hook
- update full resume modal styling to match blog post modal

## Testing
- `npm run lint` *(fails: `next` not found)*