### PR TITLE
Fix resume state cycle

### DIFF
--- a/src/components/fullresume/fullresume.js
+++ b/src/components/fullresume/fullresume.js
@@ -25,9 +25,8 @@ export default function FullResume(){
     }
     useEffect(()=>{getResumeData()},[])
     return (
-        <section id='fullResume' className={display}
-        onAnimationEnd={toggleDisplay}>
-            <article>
+        <section id='fullResume' className={display}>
+            <article onAnimationEnd={toggleDisplay}>
                 <button
                 className='CloseButton'
                 onClick={toggleDisplay}>


### PR DESCRIPTION
## Summary
- ensure animation completion moves resume UI state from `close` to `closed`

## Testing
- `npm run lint`
