### PR TITLE
Fix resume modal color

### DIFF
--- a/src/styles/partials/_themes.sass
+++ b/src/styles/partials/_themes.sass
@@ -38,6 +38,8 @@
   --highlight-red: #e74c3c
   --highlight-offwhite: #ecf0f1
   --shadow-color: #00000044
+  section#fullResume > article
+    color: var(--primary-dark-blue)
 
 @media (prefers-color-scheme: dark)
   header.Header,


### PR DESCRIPTION
## Summary
- keep text of the resume modal dark blue in light theme

## Testing
- `npm run lint`
- `npm run sass`
