### PR TITLE
Adjust dark mode shadows

### DIFF
--- a/src/styles/partials/_blog.sass
+++ b/src/styles/partials/_blog.sass
@@ -12,7 +12,7 @@ section.blog
     text-shadow: variables.$shadow
     border-color: variables.$primary-dark-blue
     z-index: 2
-    box-shadow: inset 0 -4px 4px #00000040
+    box-shadow: inset 0 -4px 4px variables.$shadow-color
     
     > article
         width: 100%

--- a/src/styles/partials/_header.sass
+++ b/src/styles/partials/_header.sass
@@ -11,7 +11,7 @@ header.Header
     z-index: 1
     text-shadow: variables.$shadow
     justify-content: center
-    box-shadow: inset 0 -4px 4px #00000040
+    box-shadow: inset 0 -4px 4px variables.$shadow-color
     > section
         display: flex
         flex-flow: row wrap

--- a/src/styles/partials/_responsive.sass
+++ b/src/styles/partials/_responsive.sass
@@ -133,11 +133,9 @@ img
 // Disable all shadows in dark mode for readability
 [data-theme='dark'], [data-theme='dark'] *
     text-shadow: none
-    box-shadow: none
     filter: none
 
 @media (prefers-color-scheme: dark)
     *
         text-shadow: none
-        box-shadow: none
         filter: none


### PR DESCRIPTION
## Summary
- update header and blog inset shadows to use theme shadow color
- preserve box shadows in dark mode while keeping text shadows off

## Testing
- `npm run lint`
- `npm run build`