### PR TITLE
Improve button aesthetics and dark theme

### DIFF
--- a/src/styles/partials/_base.sass
+++ b/src/styles/partials/_base.sass
@@ -61,7 +61,11 @@ a, a:link
         color: variables.$primary-light-blue
         transition: all 0.05s ease-in-out
 button
+    // Fluid gradient background for all buttons
     background-color: variables.$primary-light-blue
+    background-image: linear-gradient(45deg, variables.$primary-light-blue, variables.$secondary-green)
+    background-size: 200% 100%
+    background-position: left center
     padding: variables.$margin
     font-family: variables.$secondary-font
     font-size: 18px
@@ -70,12 +74,12 @@ button
     border: none
     box-shadow: variables.$shadow
     color: variables.$highlight-offwhite
+    transition: background-position 0.3s ease, color 0.05s ease-in-out
     &:hover
         color: white
-        background-color: variables.$primary-opaque-blue
-        transition: all 0.05s ease-in-out
+        background-position: right center
     &:active
-        background-color: variables.$primary-opaque-blue
+        background-position: right center
         color: white
 img
     border-radius: variables.$radius

--- a/src/styles/partials/_modals.sass
+++ b/src/styles/partials/_modals.sass
@@ -73,7 +73,8 @@ button.CloseButton
     position: absolute
     height: min-content
     line-height: 0
-    background-color: none
+    // Override global button gradient for the close button
+    background: none
     right: variables.$margin
     top: variables.$margin
 

--- a/src/styles/partials/_themes.sass
+++ b/src/styles/partials/_themes.sass
@@ -1,4 +1,5 @@
 :root
+  // Light theme palette
   --primary-dark-blue: #2c3e50
   --primary-light-blue: #2980B9
   --primary-opaque-blue: #2773a5
@@ -10,23 +11,25 @@
 
 @media (prefers-color-scheme: dark)
   :root
-    --primary-dark-blue: #1a1a1a
-    --primary-light-blue: #3498db
-    --primary-opaque-blue: #2c3e50
+    // Dark theme palette keeps the same variety of colors but shifts to deep blues
+    --primary-dark-blue: #0d1b2a
+    --primary-light-blue: #1b3b6f
+    --primary-opaque-blue: #415a77
     --secondary-orange: #e67e22
     --secondary-green: #2ecc71
     --highlight-red: #e74c3c
-    --highlight-offwhite: #f1f1f1
+    --highlight-offwhite: #dce3e8
     --shadow-color: #ffffff44
 
 [data-theme='dark']
-  --primary-dark-blue: #1a1a1a
-  --primary-light-blue: #3498db
-  --primary-opaque-blue: #2c3e50
+  // Mirror the deep blue palette when the user manually selects dark mode
+  --primary-dark-blue: #0d1b2a
+  --primary-light-blue: #1b3b6f
+  --primary-opaque-blue: #415a77
   --secondary-orange: #e67e22
   --secondary-green: #2ecc71
   --highlight-red: #e74c3c
-  --highlight-offwhite: #f1f1f1
+  --highlight-offwhite: #dce3e8
   --shadow-color: #ffffff44
 
 [data-theme='light']


### PR DESCRIPTION
## Summary
- apply gradient backgrounds to buttons for a fluid feel
- keep close button flat so it doesn't inherit gradients
- redesign dark theme with deep blues while keeping same color variety

## Testing
- `npm run sass`
- `npm run lint`
