### PR TITLE
Improve header contrast and accent color

### DIFF
--- a/src/styles/partials/_base.sass
+++ b/src/styles/partials/_base.sass
@@ -20,6 +20,7 @@ body
 h1, h2
     text-decoration: none
     font-family: variables.$primary-font
+    color: variables.$highlight-offwhite
 
 h1
     font-size: 48px
@@ -50,6 +51,7 @@ h3
     font-size: 20px
     font-weight: 600
     margin: 0
+    color: variables.$highlight-offwhite
 
 a, a:link
     color: variables.$highlight-offwhite
@@ -101,8 +103,4 @@ li
     z-index: 3
 
 .gradient-text
-    background: variables.$gradient-primary
-    -webkit-background-clip: text
-    background-clip: text
-    -webkit-text-fill-color: transparent
-    color: transparent
+    color: variables.$highlight-offwhite

--- a/src/styles/partials/_themes.sass
+++ b/src/styles/partials/_themes.sass
@@ -4,7 +4,7 @@
   --primary-light-blue: #2980B9
   --primary-opaque-blue: #2773a5
   --secondary-orange: #f39C12
-  --secondary-green: #27AE60
+  --secondary-green: #6B7A8F
   --highlight-red: #e74c3c
   --highlight-offwhite: #ecf0f1
   --shadow-color: #00000044
@@ -18,7 +18,7 @@
     --primary-light-blue: #1b3b6f
     --primary-opaque-blue: #415a77
     --secondary-orange: #e67e22
-    --secondary-green: #2ecc71
+    --secondary-green: #6B7A8F
     --highlight-red: #e74c3c
     --highlight-offwhite: #dce3e8
     --shadow-color: #ffffff44
@@ -29,7 +29,7 @@
   --primary-light-blue: #1b3b6f
   --primary-opaque-blue: #415a77
   --secondary-orange: #e67e22
-  --secondary-green: #2ecc71
+  --secondary-green: #6B7A8F
   --highlight-red: #e74c3c
   --highlight-offwhite: #dce3e8
   --shadow-color: #ffffff44
@@ -41,7 +41,7 @@
   --primary-light-blue: #2980B9
   --primary-opaque-blue: #2773a5
   --secondary-orange: #f39C12
-  --secondary-green: #27AE60
+  --secondary-green: #6B7A8F
   --highlight-red: #e74c3c
   --highlight-offwhite: #ecf0f1
   --shadow-color: #00000044


### PR DESCRIPTION
## Summary
- adjust heading styles for better readability
- use lighter text for gradient headers
- swap green accent with a mid gray blue

## Testing
- `npm run lint` *(fails: `npm` not found)*