### PR TITLE
Apply muted theme redesign

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -6,7 +6,6 @@ import FullResume from '@/components/fullresume/fullresume'
 import FullResumeState from '@/components/providers/fullresumestate'
 import PostBrowserProvider from '@/components/providers/postbrowserstate'
 import PostBrowser from '@/components/postbrowser/postbrowser'
-import ThemeToggle from '@/components/themeToggle'
 import '@/styles/style.sass'
 import { config } from '@fortawesome/fontawesome-svg-core'
 import '@fortawesome/fontawesome-svg-core/styles.css'
@@ -14,9 +13,6 @@ config.autoAddCss = false;
 export default function Page(){
     return (
         <>
-            <div className='page-theme-toggle'>
-                <ThemeToggle/>
-            </div>
             <Nav/>
             <Header/>
             <PostBrowserProvider>

--- a/src/components/about.js
+++ b/src/components/about.js
@@ -3,8 +3,8 @@ export default function About(){
     return (
         <Reveal as='section' id='about' className='about'>
             <article>
-                <h1 className='gradient-text'>About Me</h1>
-                <h2 className='gradient-text'>Origins of an Engineer</h2>
+                <h1>About Me</h1>
+                <h2>Origins of an Engineer</h2>
                 <hr/>
                 <p>
                     I never expected to dive deeply into software engineering, in-fact, before high school

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -4,6 +4,7 @@ import NavList from './navlist'
 import Chevron from '@/images/chevron.svg'
 import Image from 'next/image'
 import {useState} from 'react'
+import ThemeToggle from '@/components/themeToggle'
 
 export default function Nav(){
     const [animation, setAnimation] = useState('')
@@ -32,6 +33,7 @@ export default function Nav(){
                         onClick={toggleMenu}
                         onAnimationEnd={handleEndOfAnimation}
                     />
+                    <ThemeToggle />
                 </section>
                 <NavList className={`nav-list ${animation}`} onAnimationEnd={handleEndOfAnimation}/>
             </section>

--- a/src/components/themeToggle.js
+++ b/src/components/themeToggle.js
@@ -10,13 +10,13 @@ export default function ThemeToggle(){
         const prefersDark = typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
         const initial = saved || (prefersDark ? 'dark' : 'light')
         setTheme(initial)
-        if (typeof document !== 'undefined') document.documentElement.setAttribute('data-theme', initial)
+        if (typeof document !== 'undefined') document.documentElement.classList.toggle('dark', initial === 'dark')
     }, [])
 
     const toggleTheme = () => {
         const newTheme = theme === 'dark' ? 'light' : 'dark'
         setTheme(newTheme)
-        if (typeof document !== 'undefined') document.documentElement.setAttribute('data-theme', newTheme)
+        if (typeof document !== 'undefined') document.documentElement.classList.toggle('dark', newTheme === 'dark')
         if (typeof window !== 'undefined') localStorage.setItem('theme', newTheme)
     }
 

--- a/src/styles/partials/_ai-assistant.sass
+++ b/src/styles/partials/_ai-assistant.sass
@@ -5,8 +5,8 @@
   position: fixed
   bottom: variables.$margin
   right: variables.$margin
-  background: variables.$gradient-primary
-  color: variables.$highlight-offwhite
+  background: variables.$surface
+  color: variables.$text
   border-radius: variables.$radius
   box-shadow: variables.$shadow
   z-index: 10
@@ -27,9 +27,9 @@
     justify-content: center
     align-items: center
     cursor: pointer
-    background: variables.$gradient-secondary
+    background: variables.$accent
     border: none
-    color: variables.$primary-dark-blue
+    color: variables.$surface
     font-size: 24px
   &-content
     display: none
@@ -45,7 +45,7 @@
     justify-content: space-between
     align-items: center
     padding: variables.$margin-half
-    background: variables.$gradient-primary
+    background: variables.$primary
     border-radius: variables.$radius variables.$radius 0 0
     margin-bottom: variables.$margin-half
     
@@ -56,7 +56,7 @@
     flex: 1
     overflow-y: auto
     margin-bottom: variables.$margin
-    background-color: rgba(variables.$highlight-offwhite, 0.05)
+    background-color: rgba(0,0,0,0.05)
     border-radius: variables.$radius
     padding: variables.$margin-half
     
@@ -67,14 +67,14 @@
       max-width: 80%
       
       &.user
-        background: variables.$gradient-secondary
-        color: variables.$primary-dark-blue
+        background: variables.$primary-tint
+        color: variables.$text
         align-self: flex-end
         margin-left: auto
         
       &.assistant
-        background: variables.$gradient-primary
-        color: variables.$highlight-offwhite
+        background: variables.$primary
+        color: variables.$surface
         align-self: flex-start
         margin-right: auto
         
@@ -86,17 +86,17 @@
       padding: variables.$margin-half
       border-radius: variables.$radius 0 0 variables.$radius
       border: none
-      background-color: rgba(variables.$highlight-offwhite, 0.2)
-      color: variables.$highlight-offwhite
+      background-color: rgba(0,0,0,0.2)
+      color: variables.$text
       font-family: variables.$secondary-font
       
       &::placeholder
-        color: rgba(variables.$highlight-offwhite, 0.7)
+        color: rgba(0,0,0,0.5)
         
     button
       padding: variables.$margin-half
       border-radius: 0 variables.$radius variables.$radius 0
       border: none
-      background: variables.$gradient-secondary
-      color: variables.$primary-dark-blue
+      background: variables.$accent
+      color: variables.$surface
       cursor: pointer

--- a/src/styles/partials/_base.sass
+++ b/src/styles/partials/_base.sass
@@ -15,12 +15,15 @@ body
     grid-template-areas: "nav" "head" "main" "foot"
     grid-template-rows: auto auto auto 1fr
     grid-template-columns: auto
+    color: variables.$text
+    background: variables.$bg
 
 // Base typography
-h1, h2
+h1, h2, h3
     text-decoration: none
     font-family: variables.$primary-font
-    color: variables.$highlight-offwhite
+    color: variables.$text
+    text-shadow: none
 
 h1
     font-size: 36px
@@ -34,8 +37,8 @@ h2
     margin: 0 0 calc(variables.$margin / 2.5) 0
 
 hr
-    border: 1px solid variables.$secondary-orange
-    box-shadow: variables.$shadow
+    border: 1px solid variables.$border
+    box-shadow: none
 
 p, h3, strong
     font-family: variables.$primary-font
@@ -44,6 +47,7 @@ p, h3, strong
     letter-spacing: 0
     font-weight: 500
     margin: variables.$margin 0
+    color: variables.$text
 
 strong
     font-weight: 600
@@ -52,17 +56,18 @@ h3
     font-size: 20px
     font-weight: 600
     margin: 0
-    color: variables.$highlight-offwhite
+    color: variables.$text
 
 a, a:link
-    color: variables.$highlight-offwhite
+    color: variables.$primary
     font-family: variables.$primary-font
     font-size: 16px
     text-decoration: none
-    text-shadow: variables.$shadow
+    text-shadow: none
+    transition: color 0.15s ease-in
     &:hover, &:active
-        color: variables.$primary-light-blue
-        transition: all 0.05s ease-in-out
+        color: variables.$primary
+        text-decoration: underline
 .btn
     padding: 16px 32px
     font-family: variables.$primary-font
@@ -79,16 +84,16 @@ a, a:link
         transform: scale(1.05)
 
 .btn-primary
-    background: variables.$accent
-    color: variables.$neutral-light
+    background: variables.$primary
+    color: variables.$surface
 
 .btn-outline
     background: transparent
-    border: 1px solid variables.$accent
-    color: variables.$accent
+    border: 1px solid variables.$primary
+    color: variables.$primary
     &:hover
-        background: variables.$accent
-        color: variables.$neutral-light
+        background: variables.$primary
+        color: variables.$surface
 img
     border-radius: variables.$radius
     width: calc(320px - variables.$margin-double)
@@ -106,11 +111,6 @@ li
     font-size: 18px
     font-weight: 400
 
-.page-theme-toggle
-    position: fixed
-    bottom: variables.$margin
-    left: variables.$margin
-    z-index: 3
 
 .theme-toggle
     background: none
@@ -121,11 +121,8 @@ li
         transform: rotate(360deg)
 
 .gradient-text
-    background: variables.$gradient-secondary
-    -webkit-background-clip: text
-    background-clip: text
-    -webkit-text-fill-color: transparent
-    color: transparent
+    background: none
+    color: variables.$primary
 
 .reveal
     opacity: 0

--- a/src/styles/partials/_blog.sass
+++ b/src/styles/partials/_blog.sass
@@ -7,12 +7,12 @@ section.blog
     position: static
     flex-flow: row wrap
     justify-content: center
-    background: variables.$gradient-secondary
-    color: variables.$primary-dark-blue
-    text-shadow: variables.$shadow
-    border-color: variables.$primary-dark-blue
+    background: variables.$bg
+    color: variables.$text
+    text-shadow: none
+    border-color: variables.$text
     z-index: 2
-    box-shadow: inset 0 -4px 4px variables.$shadow-color
+    box-shadow: none
     
     > article
         width: 100%
@@ -37,8 +37,8 @@ section.blog-post
         width: calc(100vw - variables.$margin-double)
         margin: variables.$margin variables.$margin variables.$margin 0
         padding-bottom: variables.$margin
-        background: variables.$gradient-primary
-        color: variables.$highlight-offwhite
+        background: variables.$surface
+        color: variables.$text
         box-shadow: variables.$shadow
         border-radius: variables.$radius
     
@@ -59,24 +59,24 @@ section.blog-post
         overflow: hidden
         font-size: 18px
         font-weight: 400
-        color: variables.$primary-dark-blue
+        color: variables.$text
         
         &:last-child
             font-weight: 500
     
     svg
-        color: variables.$primary-light-blue
+        color: variables.$primary
     
     section
         display: flex
         flex-flow: column nowrap
-        border-right: variables.$light-blue-border
-        border-left: variables.$light-blue-border
-        border-bottom: variables.$light-blue-border
+        border-right: 1px solid variables.$border
+        border-left: 1px solid variables.$border
+        border-bottom: 1px solid variables.$border
         margin: -3px variables.$margin 0 variables.$margin
         padding: variables.$margin-half
-        background: variables.$gradient-secondary
-        color: variables.$primary-dark-blue
+        background: variables.$primary-tint
+        color: variables.$text
         border-bottom-right-radius: variables.$radius
         border-bottom-left-radius: variables.$radius
 
@@ -88,7 +88,7 @@ section.blog-post.big
     position: fixed
     align-items: center
     justify-content: center
-    background: variables.$gradient-primary
+    background: rgba(0,0,0,0.8)
     z-index: 2
     top: 0
     left: 0
@@ -109,9 +109,9 @@ section.blog-post.big
     position: fixed
     width: 100vw
     height: 100vh
-    background: variables.$gradient-primary
-    color: variables.$primary-dark-blue
-    text-shadow: variables.$shadow
+    background: rgba(0,0,0,0.8)
+    color: variables.$text
+    text-shadow: none
     display: none
     flex-flow: column nowrap
     justify-content: center
@@ -125,7 +125,7 @@ section.blog-post.big
         height: 100vh
         overflow-y: hidden
         flex-flow: column nowrap
-        background: variables.$gradient-secondary
+        background: variables.$surface
         width: calc(100% - variables.$margin-double)
         padding: variables.$margin
         animation: none

--- a/src/styles/partials/_contact.sass
+++ b/src/styles/partials/_contact.sass
@@ -2,14 +2,14 @@
 
 // Contact section styles
 section.contact
-    background: variables.$gradient-secondary
-    color: variables.$primary-dark-blue
-    text-shadow: variables.$shadow
-    box-shadow: inset variables.$shadow
+    background: variables.$bg
+    color: variables.$text
+    text-shadow: none
+    box-shadow: none
     > article
         margin: variables.$margin
     hr
-        border: 1px solid variables.$primary-dark-blue
+        border: 1px solid variables.$border
     
     form
         margin-top: variables.$margin

--- a/src/styles/partials/_footer.sass
+++ b/src/styles/partials/_footer.sass
@@ -3,8 +3,8 @@
 // Footer styles
 footer.Footer
     grid-area: foot
-    background: variables.$gradient-primary
-    color: variables.$highlight-offwhite
+    background: variables.$surface
+    color: variables.$text
     font-family: variables.$secondary-font
     
     nav

--- a/src/styles/partials/_header.sass
+++ b/src/styles/partials/_header.sass
@@ -6,12 +6,12 @@ header.Header
     grid-area: head
     display: flex
     flex-flow: row nowrap
-    background: variables.$gradient-primary
-    color: variables.$primary-dark-blue
+    background: variables.$primary-tint
+    color: variables.$text
     z-index: 1
-    text-shadow: variables.$shadow
+    text-shadow: none
     justify-content: center
-    box-shadow: inset 0 -4px 4px variables.$shadow-color
+    border-bottom: 1px solid variables.$border
     > section
         display: flex
         flex-flow: row wrap

--- a/src/styles/partials/_main.sass
+++ b/src/styles/partials/_main.sass
@@ -12,25 +12,25 @@ main.Main
             padding: variables.$section-padding-tablet 0
 // eResume section
 section.eresume
-    background: variables.$gradient-primary
-    box-shadow: variables.$shadow
+    background: variables.$surface
+    box-shadow: none
     z-index: 1
     > article
         width: calc(100% - (variables.$margin-double))
         display: flex
         flex-flow: row wrap
         justify-content: space-between
-        color: variables.$highlight-offwhite
-        text-shadow: variables.$shadow
+        color: variables.$text
+        text-shadow: none
         margin: variables.$margin
         padding: 0
     aside
         margin-top: variables.$margin
     hr
-        border: 1px solid variables.$secondary-orange
+        border: 1px solid variables.$border
 // Card components
 section.card
-    background: variables.$neutral-dark
+    background: variables.$surface
     padding: 24px
     border-radius: 16px
     box-shadow: variables.$shadow
@@ -47,20 +47,20 @@ section.card
         flex-flow: column nowrap
         overflow: scroll
         height: 100px
-        background: variables.$gradient-primary
-        border: 1px solid variables.$secondary-orange
+        background: variables.$primary-tint
+        border: 1px solid variables.$border
         border-radius: variables.$radius
         margin: variables.$margin-half 0 0 0
         padding: variables.$margin-half variables.$margin
-        box-shadow: inset variables.$shadow
+        box-shadow: none
 
 // About section
 section.about
-    background: variables.$gradient-primary
-    color: variables.$highlight-offwhite
-    text-shadow: variables.$shadow
+    background: variables.$bg
+    color: variables.$text
+    text-shadow: none
     height: 500px
     overflow-y: scroll
-    box-shadow: variables.$shadow
+    box-shadow: none
     > article
         margin: variables.$margin

--- a/src/styles/partials/_modals.sass
+++ b/src/styles/partials/_modals.sass
@@ -6,9 +6,9 @@ section#fullResume
     position: fixed
     width: 100vw
     height: 100vh
-    background: variables.$gradient-primary
-    color: variables.$primary-dark-blue
-    text-shadow: variables.$shadow
+    background: rgba(0,0,0,0.8)
+    color: variables.$text
+    text-shadow: none
     display: none
     flex-flow: column nowrap
     justify-content: center
@@ -22,7 +22,7 @@ section#fullResume
         height: 100vh
         overflow-y: scroll
         flex-flow: column nowrap
-        background: variables.$gradient-secondary
+        background: variables.$surface
         width: calc(100% - variables.$margin-double)
         padding: variables.$margin
         box-shadow: variables.$shadow

--- a/src/styles/partials/_navigation.sass
+++ b/src/styles/partials/_navigation.sass
@@ -4,8 +4,8 @@
 nav.Nav
     grid-area: nav
     position: relative
-    background: variables.$gradient-primary
-    box-shadow: variables.$shadow
+    background: var(--clr-surface)
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1)
     z-index: 2
     > section
         display: grid
@@ -19,7 +19,7 @@ nav.Nav
         position: absolute
         flex-flow: column nowrap
         justify-content: flex-start
-        background: variables.$gradient-secondary
+        background: var(--clr-bg)
         transform: translateY(-100%) scale3d(0,0,0)
 
         &.close
@@ -53,12 +53,12 @@ nav.Nav
 
 section.menu-chevron-container, section.menu-logo-container
     grid-area: menu
-    background: variables.$gradient-primary
+    background: inherit
     width: 100%
     height: 100%
     display: flex
     justify-content: flex-end
-    align-content: flex-end
+    align-items: center
     z-index: 1
 
 section.menu-logo-container
@@ -72,10 +72,22 @@ img.menu-chevron
     object-fit: fill
     margin: variables.$margin-double
     box-shadow: none
-    filter: drop-shadow(variables.$shadow)
+    filter: none
     justify-self: end
-    align-self: end
+    align-self: center
     transform: rotateZ(90deg)
+
+nav.Nav .theme-toggle
+    background: var(--clr-accent)
+    color: var(--clr-surface)
+    border: none
+    border-radius: 999px
+    padding: 0.5rem 0.6rem
+    margin: 0 0.5rem
+    cursor: pointer
+    display: flex
+    align-items: center
+    justify-content: center
 
 // Navigation animations
 @keyframes menu-chevron-move

--- a/src/styles/partials/_responsive.sass
+++ b/src/styles/partials/_responsive.sass
@@ -131,11 +131,7 @@ img
             height: variables.$post-iframe-height-xl
 
 // Disable all shadows in dark mode for readability
-[data-theme='dark'], [data-theme='dark'] *
+[class~='dark'], .dark *
     text-shadow: none
     filter: none
 
-@media (prefers-color-scheme: dark)
-    *
-        text-shadow: none
-        filter: none

--- a/src/styles/partials/_themes.sass
+++ b/src/styles/partials/_themes.sass
@@ -1,77 +1,16 @@
 :root
-  // Light theme palette
-  --primary-dark-blue: #2c3e50
-  --primary-light-blue: #2980B9
-  --primary-opaque-blue: #2773a5
-  --secondary-orange: #f39C12
-  --secondary-green: #6B7A8F
-  --highlight-red: #e74c3c
-  --highlight-offwhite: #ecf0f1
-  --shadow-color: #00000044
-  --gradient-primary: linear-gradient(135deg, #0ea5e9, #a855f7)
-  --gradient-secondary: linear-gradient(135deg, #ec4899, #f97316)
-  --primary: #1f2937
-  --accent: #3b82f6
-  --neutral-light: #f8f8f8
-  --neutral-dark: #1f1f1f
+  --clr-primary: #2563EB
+  --clr-primary-tint: #DBEAFE
+  --clr-accent: #F59E0B
+  --clr-bg: #F9FAFB
+  --clr-surface: #FFFFFF
+  --clr-text: #1F2937
+  --clr-text-secondary: #4B5563
+  --clr-border: #E5E7EB
 
-@media (prefers-color-scheme: dark)
-  :root
-    // Dark theme palette keeps the same variety of colors but shifts to deep blues
-    --primary-dark-blue: #0d1b2a
-    --primary-light-blue: #1b3b6f
-    --primary-opaque-blue: #415a77
-    --secondary-orange: #e67e22
-    --secondary-green: #6B7A8F
-    --highlight-red: #e74c3c
-    --highlight-offwhite: #dce3e8
-    --shadow-color: #ffffff44
-
-[data-theme='dark']
-  // Mirror the deep blue palette when the user manually selects dark mode
-  --primary-dark-blue: #0d1b2a
-  --primary-light-blue: #1b3b6f
-  --primary-opaque-blue: #415a77
-  --secondary-orange: #e67e22
-  --secondary-green: #6B7A8F
-  --highlight-red: #e74c3c
-  --highlight-offwhite: #dce3e8
-  --shadow-color: #ffffff44
-  --gradient-primary: linear-gradient(135deg, #0ea5e9, #a855f7)
-  --gradient-secondary: linear-gradient(135deg, #ec4899, #f97316)
-  --primary: #1f2937
-  --accent: #3b82f6
-  --neutral-light: #f8f8f8
-  --neutral-dark: #1f1f1f
-
-[data-theme='light']
-  --primary-dark-blue: #2c3e50
-  --primary-light-blue: #2980B9
-  --primary-opaque-blue: #2773a5
-  --secondary-orange: #f39C12
-  --secondary-green: #6B7A8F
-  --highlight-red: #e74c3c
-  --highlight-offwhite: #ecf0f1
-  --shadow-color: #00000044
-  --gradient-primary: linear-gradient(135deg, #0ea5e9, #a855f7)
-  --gradient-secondary: linear-gradient(135deg, #ec4899, #f97316)
-  section#fullResume > article
-    color: var(--primary-dark-blue)
-
-@media (prefers-color-scheme: dark)
-  header.Header,
-  section.blog,
-  section.blog-post > section,
-  section.contact,
-  section#fullResume > article
-    background-color: var(--primary-dark-blue)
-    color: var(--highlight-offwhite)
-
-[data-theme='dark']
-  header.Header,
-  section.blog,
-  section.blog-post > section,
-  section.contact,
-  section#fullResume > article
-    background-color: var(--primary-dark-blue)
-    color: var(--highlight-offwhite)
+.dark
+  --clr-bg: #111827
+  --clr-surface: #1F2937
+  --clr-text: #F9FAFB
+  --clr-text-secondary: #D1D5DB
+  --clr-border: #374151

--- a/src/styles/partials/_variables.sass
+++ b/src/styles/partials/_variables.sass
@@ -1,15 +1,15 @@
 // Variables
-$primary-dark-blue: var(--primary-dark-blue)
-$primary-light-blue: var(--primary-light-blue)
-$primary-opaque-blue: var(--primary-opaque-blue)
-$light-blue-border: 2px solid $primary-light-blue
-$secondary-orange: var(--secondary-orange)
-$secondary-green: var(--secondary-green)
-$highlight-red: var(--highlight-red)
-$highlight-offwhite: var(--highlight-offwhite)
-$shadow-color: var(--shadow-color)
-$gradient-primary: var(--gradient-primary)
-$gradient-secondary: var(--gradient-secondary)
+$primary: var(--clr-primary)
+$primary-tint: var(--clr-primary-tint)
+$accent: var(--clr-accent)
+$surface: var(--clr-surface)
+$bg: var(--clr-bg)
+$text: var(--clr-text)
+$text-secondary: var(--clr-text-secondary)
+$border: var(--clr-border)
+$highlight-red: #e74c3c
+$shadow: 0 4px 8px rgba(0,0,0,0.1)
+$radius: 16px
 
 // Spacing
 $margin-half: 0.5rem
@@ -22,19 +22,10 @@ $margin-quadruple: 4rem
 $primary-font: var(--font-sans), 'Work Sans', sans-serif
 $secondary-font: var(--font-sans), 'Work Sans', sans-serif
 
-// Design tokens
-$primary: var(--primary)
-$accent: var(--accent)
-$neutral-light: var(--neutral-light)
-$neutral-dark: var(--neutral-dark)
-
+// Layout
 $section-padding-desktop: 80px
 $section-padding-tablet: 40px
 $gap: 24px
-
-// Effects
-$shadow: 0px 4px 4px $shadow-color
-$radius: 16px
 
 // Breakpoints
 $width: 320px


### PR DESCRIPTION
## Summary
- overhaul theme variables to use new palette
- update Sass variables to reference the tokens
- restyle navigation, header and all sections with flat colors
- move theme toggle into nav and update logic
- remove floating toggle wrapper
- clean up dark-mode handling and gradients

## Testing
- `npm run sass`
- `npm run lint`
