### PR TITLE
Fix text contrast for colored backgrounds

### DIFF
--- a/src/styles/partials/_ai-assistant.sass
+++ b/src/styles/partials/_ai-assistant.sass
@@ -29,7 +29,7 @@
     cursor: pointer
     background: variables.$accent
     border: none
-    color: variables.$surface
+    color: var(--clr-dark)
     font-size: 24px
   &-content
     display: none
@@ -68,13 +68,13 @@
       
       &.user
         background: variables.$primary-tint
-        color: variables.$text
+        color: var(--clr-dark)
         align-self: flex-end
         margin-left: auto
-        
+
       &.assistant
         background: variables.$primary
-        color: variables.$surface
+        color: var(--clr-light)
         align-self: flex-start
         margin-right: auto
         
@@ -98,5 +98,5 @@
       border-radius: 0 variables.$radius variables.$radius 0
       border: none
       background: variables.$accent
-      color: variables.$surface
+      color: var(--clr-dark)
       cursor: pointer

--- a/src/styles/partials/_blog.sass
+++ b/src/styles/partials/_blog.sass
@@ -76,7 +76,7 @@ section.blog-post
         margin: -3px variables.$margin 0 variables.$margin
         padding: variables.$margin-half
         background: variables.$primary-tint
-        color: variables.$text
+        color: var(--clr-dark)
         border-bottom-right-radius: variables.$radius
         border-bottom-left-radius: variables.$radius
 

--- a/src/styles/partials/_header.sass
+++ b/src/styles/partials/_header.sass
@@ -7,7 +7,7 @@ header.Header
     display: flex
     flex-flow: row nowrap
     background: variables.$primary-tint
-    color: variables.$text
+    color: var(--clr-dark)
     z-index: 1
     text-shadow: none
     justify-content: center

--- a/src/styles/partials/_main.sass
+++ b/src/styles/partials/_main.sass
@@ -48,6 +48,7 @@ section.card
         overflow: scroll
         height: 100px
         background: variables.$primary-tint
+        color: var(--clr-dark)
         border: 1px solid variables.$border
         border-radius: variables.$radius
         margin: variables.$margin-half 0 0 0

--- a/src/styles/partials/_navigation.sass
+++ b/src/styles/partials/_navigation.sass
@@ -79,7 +79,7 @@ img.menu-chevron
 
 nav.Nav .theme-toggle
     background: var(--clr-accent)
-    color: var(--clr-surface)
+    color: var(--clr-dark)
     border: none
     border-radius: 999px
     padding: 0.5rem 0.6rem

--- a/src/styles/partials/_themes.sass
+++ b/src/styles/partials/_themes.sass
@@ -2,6 +2,8 @@
   --clr-primary: #2563EB
   --clr-primary-tint: #DBEAFE
   --clr-accent: #F59E0B
+  --clr-light: #F9FAFB
+  --clr-dark: #1F2937
   --clr-bg: #F9FAFB
   --clr-surface: #FFFFFF
   --clr-text: #1F2937


### PR DESCRIPTION
## Summary
- define constant light and dark colors in theme
- make header text dark on light primary tint
- adjust text on blog tint backgrounds
- ensure card lists use dark text
- improve AI assistant and theme toggle contrast

## Testing
- `npm run lint`
- `npm run sass`
