### PR TITLE
Update navigation and dark mode toggle

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -6,6 +6,7 @@ import FullResume from '@/components/fullresume/fullresume'
 import FullResumeState from '@/components/providers/fullresumestate'
 import PostBrowserProvider from '@/components/providers/postbrowserstate'
 import PostBrowser from '@/components/postbrowser/postbrowser'
+import ThemeToggle from '@/components/themeToggle'
 import '@/styles/style.sass'
 import { config } from '@fortawesome/fontawesome-svg-core'
 import '@fortawesome/fontawesome-svg-core/styles.css'
@@ -23,6 +24,7 @@ export default function Page(){
                 </FullResumeState>
             </PostBrowserProvider>
             <Footer/>
+            <ThemeToggle className='floating-theme-toggle'/>
         </>
     )
 }

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -1,17 +1,14 @@
 'use client'
 import Logo from '@/images/logo'
 import NavList from './navlist'
-import Chevron from '@/images/chevron.svg'
-import Image from 'next/image'
 import {useState, useRef} from 'react'
-import ThemeToggle from '@/components/themeToggle'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faBars, faXmark } from '@fortawesome/free-solid-svg-icons'
 
 export default function Nav(){
     const [animation, setAnimation] = useState('')
     const menuRef = useRef(null)
-    const chevronRef = useRef(null)
     const toggleMenu = () => {
-        if(chevronRef.current) chevronRef.current.classList.remove('opened')
         if(menuRef.current) menuRef.current.classList.remove('opened')
         if(animation === 'close' || animation === '') setAnimation('open')
         else if (animation === 'open' ) setAnimation('close')
@@ -34,18 +31,14 @@ export default function Nav(){
                         aria-controls='nav-list'
                         aria-expanded={(animation === 'open' || animation === 'opened') ? 'true' : 'false'}
                         onClick={toggleMenu}
+                        onAnimationEnd={handleEndOfAnimation}
                     >
-                        <Image
-                            loading='eager'
-                            src={Chevron}
-                            alt=''
+                        <FontAwesomeIcon
+                            icon={(animation === 'open' || animation === 'opened') ? faXmark : faBars}
+                            className='menu-icon icon-lg'
                             aria-hidden='true'
-                            className={`menu-chevron ${animation}`}
-                            onAnimationEnd={handleEndOfAnimation}
-                            ref={chevronRef}
                         />
                     </button>
-                    <ThemeToggle />
                 </section>
                 <NavList id='nav-list' ref={menuRef} className={`nav-list ${animation}`} onAnimationEnd={handleEndOfAnimation}/>
             </section>

--- a/src/components/themeToggle.js
+++ b/src/components/themeToggle.js
@@ -3,7 +3,7 @@ import {useState, useEffect} from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSun, faMoon } from '@fortawesome/free-regular-svg-icons'
 
-export default function ThemeToggle(){
+export default function ThemeToggle({className = ''}){
     const [theme, setTheme] = useState('light')
     useEffect(() => {
         const saved = typeof window !== 'undefined' ? localStorage.getItem('theme') : null
@@ -21,7 +21,7 @@ export default function ThemeToggle(){
     }
 
     return (
-        <button className='theme-toggle' onClick={toggleTheme} aria-label='Toggle theme'>
+        <button className={`theme-toggle ${className}`} onClick={toggleTheme} aria-label='Toggle theme'>
             {theme === 'dark' ? (
                 <FontAwesomeIcon icon={faSun} className='icon-md' />
             ) : (

--- a/src/styles/partials/_base.sass
+++ b/src/styles/partials/_base.sass
@@ -120,6 +120,20 @@ li
     &:active
         transform: rotate(360deg)
 
+.floating-theme-toggle
+    position: fixed
+    bottom: variables.$margin
+    left: variables.$margin
+    z-index: 10
+    background: var(--clr-accent)
+    color: var(--clr-dark)
+    border: none
+    border-radius: 999px
+    padding: 0.5rem 0.6rem
+    display: flex
+    align-items: center
+    justify-content: center
+
 .gradient-text
     background: none
     color: variables.$primary

--- a/src/styles/partials/_modals.sass
+++ b/src/styles/partials/_modals.sass
@@ -71,12 +71,23 @@ section#fullResume
 // Close button
 button.CloseButton
     position: absolute
-    height: min-content
-    line-height: 0
-    // Override global button gradient for the close button
-    background: none
     right: variables.$margin
     top: variables.$margin
+    width: 40px
+    height: 40px
+    line-height: 0
+    background: var(--clr-accent)
+    color: var(--clr-dark)
+    border: none
+    border-radius: 999px
+    box-shadow: variables.$shadow
+    cursor: pointer
+    display: flex
+    align-items: center
+    justify-content: center
+    transition: transform 150ms ease-in-out
+    &:hover
+        transform: scale(1.05)
 
 // Animations
 @keyframes slide-in-up

--- a/src/styles/partials/_navigation.sass
+++ b/src/styles/partials/_navigation.sass
@@ -39,17 +39,6 @@ nav.Nav
         list-style-type: none
         margin: variables.$margin
 
-    img
-        &.opened
-            transform: rotateZ(270deg)
-
-        &.open
-            animation: menu-chevron-move 0.25s ease
-            animation-fill-mode: forwards
-
-        &.close
-            animation: menu-chevron-move 0.25s ease reverse
-            animation-fill-mode: backwards
 
 section.menu-chevron-container, section.menu-logo-container
     grid-area: menu
@@ -66,34 +55,19 @@ section.menu-logo-container
     justify-content: flex-start
     align-content: center
 
-img.menu-chevron
-    width: 20px
-    height: 40px
-    object-fit: fill
-    margin: variables.$margin-double
-    box-shadow: none
-    filter: none
-    justify-self: end
-    align-self: center
-    transform: rotateZ(90deg)
-
-nav.Nav .theme-toggle
-    background: var(--clr-accent)
-    color: var(--clr-dark)
+button.MenuToggle
+    background: none
     border: none
-    border-radius: 999px
-    padding: 0.5rem 0.6rem
-    margin: 0 0.5rem
+    padding: variables.$margin-double
     cursor: pointer
     display: flex
     align-items: center
     justify-content: center
+    width: 40px
+    height: 40px
+
 
 // Navigation animations
-@keyframes menu-chevron-move
-    100%
-        transform: rotateZ(270deg)
-
 @keyframes navigation-menu
     0%
         transform: translateY(-100%) scale3d(0,0,0)

--- a/src/styles/partials/_responsive.sass
+++ b/src/styles/partials/_responsive.sass
@@ -68,7 +68,7 @@ img
         width: calc(variables.$large-width - variables.$margin-double)
     section.eresume > article, section.blog > article, section.about > article, section.contact > article, footer.Footer > nav, #fullResume
         width: variables.$large-width
-    img.menu-chevron, section.menu-chevron-container
+    button.MenuToggle, section.menu-chevron-container
         display: none
     footer.Footer
         nav


### PR DESCRIPTION
## Summary
- switch mobile nav chevron to FontAwesome hamburger
- move theme toggle to bottom-left corner
- add optional className prop for theme toggle
- adjust modal close button styling for bubbly look
- update Sass styles

## Testing
- `npm run lint`