### PR TITLE
Fix placeholder colors for dark mode

### DIFF
--- a/src/styles/partials/_ai-assistant.sass
+++ b/src/styles/partials/_ai-assistant.sass
@@ -91,7 +91,7 @@
       font-family: variables.$secondary-font
       
       &::placeholder
-        color: rgba(0,0,0,0.5)
+        color: var(--clr-placeholder)
         
     button
       padding: variables.$margin-half

--- a/src/styles/partials/_contact.sass
+++ b/src/styles/partials/_contact.sass
@@ -36,6 +36,8 @@ section.contact
                 &:focus
                     outline: none
                     border-bottom: 2px solid variables.$accent
+                &::placeholder
+                    color: var(--clr-placeholder)
         
         label
             font-family: variables.$secondary-font

--- a/src/styles/partials/_themes.sass
+++ b/src/styles/partials/_themes.sass
@@ -11,6 +11,7 @@
   --clr-text: #1F2937
   --clr-text-secondary: #4B5563
   --clr-border: #E5E7EB
+  --clr-placeholder: rgba(31,41,55,0.5)
 
 .dark
   --clr-bg: #111827
@@ -18,6 +19,7 @@
   --clr-text: #F9FAFB
   --clr-text-secondary: #D1D5DB
   --clr-border: #374151
+  --clr-placeholder: rgba(249,250,251,0.5)
   --clr-primary: var(--clr-primary-dark)
   --clr-primary-tint: var(--clr-primary-tint-dark)
 


### PR DESCRIPTION
## Summary
- add theme variable for input placeholders
- switch placeholder styles to use the new variable

## Testing
- `npm run lint` *(fails: `npm` not found)*