### PR TITLE
Enhance navigation and resume modal UI

### DIFF
--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -1,20 +1,18 @@
 'use client'
 import Logo from '@/images/logo'
 import NavList from './navlist'
-import Chevron from '@/images/chevron.svg'
-import Image from 'next/image'
 import {useState, useRef} from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faBars, faXmark } from '@fortawesome/free-solid-svg-icons'
 import ThemeToggle from '@/components/themeToggle'
 
 export default function Nav(){
     const [animation, setAnimation] = useState('')
     const menuRef = useRef(null)
-    const chevronRef = useRef(null)
     const toggleMenu = () => {
-        if(chevronRef.current) chevronRef.current.classList.remove('opened')
         if(menuRef.current) menuRef.current.classList.remove('opened')
         if(animation === 'close' || animation === '') setAnimation('open')
-        else if (animation === 'open' ) setAnimation('close')
+        else if (animation === 'open') setAnimation('close')
     }
     const handleEndOfAnimation = (e) => {
         e.target.classList.remove(animation)
@@ -27,7 +25,8 @@ export default function Nav(){
                 <section className='menu-logo-container'>
                     <Logo/>
                 </section>
-                <section className='menu-chevron-container'>
+                <ThemeToggle />
+                <section className='menu-button-container'>
                     <button
                         className='MenuToggle'
                         aria-label='Open navigation menu'
@@ -35,17 +34,11 @@ export default function Nav(){
                         aria-expanded={(animation === 'open' || animation === 'opened') ? 'true' : 'false'}
                         onClick={toggleMenu}
                     >
-                        <Image
-                            loading='eager'
-                            src={Chevron}
-                            alt=''
-                            aria-hidden='true'
-                            className={`menu-chevron ${animation}`}
-                            onAnimationEnd={handleEndOfAnimation}
-                            ref={chevronRef}
+                        <FontAwesomeIcon
+                            icon={(animation === 'open' || animation === 'opened') ? faXmark : faBars}
+                            className='menu-hamburger icon-lg'
                         />
                     </button>
-                    <ThemeToggle />
                 </section>
                 <NavList id='nav-list' ref={menuRef} className={`nav-list ${animation}`} onAnimationEnd={handleEndOfAnimation}/>
             </section>

--- a/src/styles/partials/_modals.sass
+++ b/src/styles/partials/_modals.sass
@@ -71,12 +71,21 @@ section#fullResume
 // Close button
 button.CloseButton
     position: absolute
-    height: min-content
-    line-height: 0
-    // Override global button gradient for the close button
-    background: none
     right: variables.$margin
     top: variables.$margin
+    width: 32px
+    height: 32px
+    border: none
+    border-radius: 999px
+    background: variables.$accent
+    color: var(--clr-dark)
+    display: flex
+    align-items: center
+    justify-content: center
+    box-shadow: variables.$shadow
+    transition: transform 150ms ease-in-out, background-color 150ms ease-in-out
+    &:hover
+        transform: scale(1.05)
 
 // Animations
 @keyframes slide-in-up

--- a/src/styles/partials/_navigation.sass
+++ b/src/styles/partials/_navigation.sass
@@ -9,9 +9,9 @@ nav.Nav
     z-index: 2
     > section
         display: grid
-        grid-template-areas: "logo menu" "list list"
+        grid-template-areas: "logo theme menu" "list list list"
         grid-template-rows: auto min-content
-        grid-template-columns: 1fr 1fr
+        grid-template-columns: 1fr auto auto
 
     ul
         grid-area: list
@@ -39,19 +39,8 @@ nav.Nav
         list-style-type: none
         margin: variables.$margin
 
-    img
-        &.opened
-            transform: rotateZ(270deg)
 
-        &.open
-            animation: menu-chevron-move 0.25s ease
-            animation-fill-mode: forwards
-
-        &.close
-            animation: menu-chevron-move 0.25s ease reverse
-            animation-fill-mode: backwards
-
-section.menu-chevron-container, section.menu-logo-container
+section.menu-button-container, section.menu-logo-container
     grid-area: menu
     background: inherit
     width: 100%
@@ -66,18 +55,22 @@ section.menu-logo-container
     justify-content: flex-start
     align-content: center
 
-img.menu-chevron
-    width: 20px
-    height: 40px
-    object-fit: fill
+button.MenuToggle
+    background: none
+    border: none
+    cursor: pointer
     margin: variables.$margin-double
-    box-shadow: none
-    filter: none
-    justify-self: end
-    align-self: center
-    transform: rotateZ(90deg)
+    display: flex
+    align-items: center
+    justify-content: center
+
+.menu-hamburger
+    width: 20px
+    height: 20px
+
 
 nav.Nav .theme-toggle
+    grid-area: theme
     background: var(--clr-accent)
     color: var(--clr-dark)
     border: none
@@ -90,10 +83,6 @@ nav.Nav .theme-toggle
     justify-content: center
 
 // Navigation animations
-@keyframes menu-chevron-move
-    100%
-        transform: rotateZ(270deg)
-
 @keyframes navigation-menu
     0%
         transform: translateY(-100%) scale3d(0,0,0)

--- a/src/styles/partials/_responsive.sass
+++ b/src/styles/partials/_responsive.sass
@@ -42,9 +42,9 @@ img
         > section
             justify-self: center
             width: variables.$large-width
-            grid-template-areas: 'logo list'
+            grid-template-areas: 'logo list theme'
             grid-template-rows: auto
-            grid-template-columns: min-content max-content
+            grid-template-columns: min-content max-content auto
         ul, ul.open, ul.close, ul.opened
             display: flex
             transform: none
@@ -68,7 +68,7 @@ img
         width: calc(variables.$large-width - variables.$margin-double)
     section.eresume > article, section.blog > article, section.about > article, section.contact > article, footer.Footer > nav, #fullResume
         width: variables.$large-width
-    img.menu-chevron, section.menu-chevron-container
+    section.menu-button-container
         display: none
     footer.Footer
         nav


### PR DESCRIPTION
## Summary
- replace chevron icon with FontAwesome hamburger in navigation
- expose the theme toggle outside of the menu toggle
- hide hamburger on large screens and adjust layout
- style modal close buttons using bubbly accent buttons

## Testing
- `npm run lint`
- `npm run sass`