### PR TITLE
Update nav theme toggle and bubbly close buttons

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -6,7 +6,6 @@ import FullResume from '@/components/fullresume/fullresume'
 import FullResumeState from '@/components/providers/fullresumestate'
 import PostBrowserProvider from '@/components/providers/postbrowserstate'
 import PostBrowser from '@/components/postbrowser/postbrowser'
-import ThemeToggle from '@/components/themeToggle'
 import '@/styles/style.sass'
 import { config } from '@fortawesome/fontawesome-svg-core'
 import '@fortawesome/fontawesome-svg-core/styles.css'
@@ -24,7 +23,6 @@ export default function Page(){
                 </FullResumeState>
             </PostBrowserProvider>
             <Footer/>
-            <ThemeToggle className='floating-theme-toggle'/>
         </>
     )
 }

--- a/src/components/fullresume/fullresume.js
+++ b/src/components/fullresume/fullresume.js
@@ -31,7 +31,7 @@ export default function FullResume(){
                 className='CloseButton'
                 onClick={toggleDisplay}
                 aria-label='Close resume'>
-                    <FontAwesomeIcon icon={faXmark} aria-hidden='true'/>
+                    <FontAwesomeIcon icon={faXmark} aria-hidden='true' className='icon-lg'/>
                 </button>
                 <section>
                     <h1 id='resumeTitle' className='gradient-text'>Jesse Piccione</h1>

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -4,6 +4,7 @@ import NavList from './navlist'
 import {useState, useRef} from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faBars, faXmark } from '@fortawesome/free-solid-svg-icons'
+import ThemeToggle from '@/components/themeToggle'
 
 export default function Nav(){
     const [animation, setAnimation] = useState('')
@@ -24,7 +25,7 @@ export default function Nav(){
                 <section className='menu-logo-container'>
                     <Logo/>
                 </section>
-                <section className='menu-chevron-container'>
+                <section className='menu-hamburger-container'>
                     <button
                         className='MenuToggle'
                         aria-label='Open navigation menu'
@@ -39,6 +40,7 @@ export default function Nav(){
                             aria-hidden='true'
                         />
                     </button>
+                    <ThemeToggle className='nav-theme-toggle'/>
                 </section>
                 <NavList id='nav-list' ref={menuRef} className={`nav-list ${animation}`} onAnimationEnd={handleEndOfAnimation}/>
             </section>

--- a/src/components/postbrowser/postbrowser.js
+++ b/src/components/postbrowser/postbrowser.js
@@ -33,7 +33,7 @@ export default function PostBrowser(){
         <section id='BlogPostBrowser' className={display} role='dialog' aria-modal='true' aria-labelledby='blogBrowserTitle'>
             <article onAnimationEnd={toggleDisplay}>
                 <button className='CloseButton' onClick={toggleDisplay} aria-label='Close blog posts'>
-                    <FontAwesomeIcon icon={faXmark} aria-hidden='true'/>
+                    <FontAwesomeIcon icon={faXmark} aria-hidden='true' className='icon-lg'/>
                 </button>
                 <h1 id='blogBrowserTitle' className='gradient-text'>Jesse's Blog</h1>
                 <hr/>

--- a/src/styles/partials/_modals.sass
+++ b/src/styles/partials/_modals.sass
@@ -73,8 +73,8 @@ button.CloseButton
     position: absolute
     right: variables.$margin
     top: variables.$margin
-    width: 40px
-    height: 40px
+    width: 48px
+    height: 48px
     line-height: 0
     background: var(--clr-accent)
     color: var(--clr-dark)
@@ -85,6 +85,7 @@ button.CloseButton
     display: flex
     align-items: center
     justify-content: center
+    font-size: 1.25rem
     transition: transform 150ms ease-in-out
     &:hover
         transform: scale(1.05)

--- a/src/styles/partials/_navigation.sass
+++ b/src/styles/partials/_navigation.sass
@@ -40,7 +40,7 @@ nav.Nav
         margin: variables.$margin
 
 
-section.menu-chevron-container, section.menu-logo-container
+section.menu-hamburger-container, section.menu-logo-container
     grid-area: menu
     background: inherit
     width: 100%
@@ -65,6 +65,18 @@ button.MenuToggle
     justify-content: center
     width: 40px
     height: 40px
+
+.nav-theme-toggle
+    background: var(--clr-accent)
+    color: var(--clr-dark)
+    border: none
+    border-radius: 999px
+    box-shadow: variables.$shadow
+    padding: 0.5rem 0.6rem
+    margin-left: variables.$margin-half
+    display: flex
+    align-items: center
+    justify-content: center
 
 
 // Navigation animations

--- a/src/styles/partials/_responsive.sass
+++ b/src/styles/partials/_responsive.sass
@@ -68,7 +68,7 @@ img
         width: calc(variables.$large-width - variables.$margin-double)
     section.eresume > article, section.blog > article, section.about > article, section.contact > article, footer.Footer > nav, #fullResume
         width: variables.$large-width
-    button.MenuToggle, section.menu-chevron-container
+    button.MenuToggle, section.menu-hamburger-container
         display: none
     footer.Footer
         nav


### PR DESCRIPTION
## Summary
- switch nav chevron to hamburger container and include ThemeToggle
- style nav theme toggle
- hide menu toggle container on wide screens
- make modal close buttons larger and use icon-lg

## Testing
- `npm run sass`
- `npm run build` *(fails: connect EHOSTUNREACH)*