### PR TITLE
Make theme toggle floating

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,4 +1,5 @@
 import { Work_Sans } from 'next/font/google'
+import ThemeToggle from '@/components/themeToggle'
 
 const workSans = Work_Sans({
     weight: ['400', '600', '800'],
@@ -42,6 +43,7 @@ export default function RootLayout(props){
         <html lang='en' className={workSans.variable}>
             <body>
                 {props.children}
+                <ThemeToggle className='floating-theme-toggle'/>
             </body>
         </html>
     )

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -4,7 +4,6 @@ import NavList from './navlist'
 import {useState, useRef} from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faBars, faXmark } from '@fortawesome/free-solid-svg-icons'
-import ThemeToggle from '@/components/themeToggle'
 
 export default function Nav(){
     const [animation, setAnimation] = useState('')
@@ -40,7 +39,6 @@ export default function Nav(){
                             aria-hidden='true'
                         />
                     </button>
-                    <ThemeToggle className='nav-theme-toggle'/>
                 </section>
                 <NavList id='nav-list' ref={menuRef} className={`nav-list ${animation}`} onAnimationEnd={handleEndOfAnimation}/>
             </section>


### PR DESCRIPTION
## Summary
- remove theme toggle from navigation
- show the theme toggle as a floating button on every page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*