### PR TITLE
Add interactive hover animations

### DIFF
--- a/src/styles/partials/_ai-assistant.sass
+++ b/src/styles/partials/_ai-assistant.sass
@@ -31,6 +31,9 @@
     border: none
     color: var(--clr-dark)
     font-size: 24px
+    transition: transform 0.2s ease
+    &:hover
+      transform: scale(1.05)
   &-content
     display: none
     flex-direction: column

--- a/src/styles/partials/_base.sass
+++ b/src/styles/partials/_base.sass
@@ -120,6 +120,8 @@ li
     border: none
     cursor: pointer
     transition: transform 0.25s ease
+    &:hover
+        transform: scale(1.1)
     &:active
         transform: rotate(360deg)
 

--- a/src/styles/partials/_blog.sass
+++ b/src/styles/partials/_blog.sass
@@ -41,6 +41,10 @@ section.blog-post
         color: variables.$text
         box-shadow: variables.$shadow
         border-radius: variables.$radius
+        transition: transform 0.2s ease, box-shadow 0.2s ease
+        &:hover
+            transform: translateY(-4px)
+            box-shadow: 0 8px 16px rgba(0,0,0,0.15)
     
     &:last-child > article
         margin: variables.$margin 0

--- a/src/styles/partials/_contact.sass
+++ b/src/styles/partials/_contact.sass
@@ -33,10 +33,11 @@ section.contact
                 background: transparent
                 border-radius: 0
                 box-shadow: none
-                transition: border-color 150ms
+                transition: border-color 150ms, transform 0.2s ease
                 &:focus
                     outline: none
                     border-bottom: 2px solid variables.$accent
+                    transform: scale(1.02)
                 &::placeholder
                     color: var(--clr-placeholder)
         
@@ -56,6 +57,9 @@ section.contact
         
         button[type='submit']
             margin-top: calc( variables.$margin / 2 )
+            transition: transform 0.2s ease
+            &:hover
+                transform: scale(1.05)
 
         input.error, textarea.error
             border-bottom-color: red

--- a/src/styles/partials/_footer.sass
+++ b/src/styles/partials/_footer.sass
@@ -38,4 +38,4 @@ footer.Footer
             transform: translateX(4px)
             color: variables.$accent
             svg
-                transform: scale(1.1)
+                transform: scale(1.1) rotate(10deg)

--- a/src/styles/partials/_header.sass
+++ b/src/styles/partials/_header.sass
@@ -19,6 +19,10 @@ header.Header
         padding: variables.$margin
     aside
         margin-top: variables.$margin
+        .profile-img
+            transition: transform 0.3s ease
+            &:hover
+                transform: rotate(5deg) scale(1.05)
     > section > section, aside
         display: flex
         flex-flow: column wrap

--- a/src/styles/partials/_main.sass
+++ b/src/styles/partials/_main.sass
@@ -69,3 +69,6 @@ section.about
     box-shadow: none
     > article
         margin: variables.$margin
+        transition: box-shadow 0.2s ease
+        &:hover
+            box-shadow: variables.$shadow

--- a/src/styles/partials/_navigation.sass
+++ b/src/styles/partials/_navigation.sass
@@ -41,6 +41,14 @@ nav.Nav
         transition: transform 0.2s ease
         &:hover
             transform: translateY(-2px)
+        a
+            display: flex
+            align-items: center
+            gap: variables.$margin-half
+            transition: color 0.2s ease, transform 0.2s ease
+            &:hover
+                color: variables.$accent
+                transform: scale(1.05)
 
 
 section.menu-hamburger-container, section.menu-logo-container


### PR DESCRIPTION
## Summary
- spruce up theme toggle icon and blog cards
- add fun animations for the AI assistant button
- animate contact form fields, footer icons, profile image, and nav links
- let the about section cast a shadow on hover

## Testing
- `npm run sass`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a4c3c4e4832590cb32fdaf87dbe7