### PR TITLE
Fix social link labels

### DIFF
--- a/src/components/socialmedialist.js
+++ b/src/components/socialmedialist.js
@@ -6,21 +6,25 @@ export default function SocialMediaList(){
             <li key='linkedin'>
                 <a href='https://www.linkedin.com/in/jesse-piccione' aria-label='LinkedIn'>
                     <FontAwesomeIcon icon={faLinkedin} className='icon-lg' />
+                    <span>LinkedIn</span>
                 </a>
             </li>
             <li key='github'>
                 <a href='https://www.github.com/jessepiccione' aria-label='GitHub'>
                     <FontAwesomeIcon icon={faGithub} className='icon-lg' />
+                    <span>GitHub</span>
                 </a>
             </li>
             <li key='facebook'>
                 <a href='https://www.facebook.com/jesse.piccione' aria-label='Facebook'>
                     <FontAwesomeIcon icon={faFacebook} className='icon-lg' />
+                    <span>Facebook</span>
                 </a>
             </li>
             <li key='instagram'>
                 <a href='https://www.instagram.com/jessepiccione' aria-label='Instagram'>
                     <FontAwesomeIcon icon={faInstagram} className='icon-lg' />
+                    <span>Instagram</span>
                 </a>
             </li>
         </ul>


### PR DESCRIPTION
## Summary
- show link titles after icons in the footer

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841e827b5408325aadd208ae81be674