### PR TITLE
Improve spacing around icons

### DIFF
--- a/src/components/AIAssistant.js
+++ b/src/components/AIAssistant.js
@@ -89,9 +89,9 @@ const AIAssistant = () => {
     <div className={`ai-assistant ${isExpanded ? 'expanded' : ''}`}>
       <button className="ai-assistant-toggle" onClick={toggleExpanded}>
         {isExpanded ? (
-          <FontAwesomeIcon icon={faTimes} />
+          <FontAwesomeIcon icon={faTimes} className='icon-md' />
         ) : (
-          <FontAwesomeIcon icon={faRobot} />
+          <FontAwesomeIcon icon={faRobot} className='icon-md' />
         )}
       </button>
       
@@ -118,7 +118,7 @@ const AIAssistant = () => {
             onKeyPress={handleKeyPress}
           />
           <button onClick={handleSendMessage}>
-            <FontAwesomeIcon icon={faPaperPlane} />
+            <FontAwesomeIcon icon={faPaperPlane} className='icon-md' />
           </button>
         </div>
       </div>

--- a/src/components/contactinfolist.js
+++ b/src/components/contactinfolist.js
@@ -5,21 +5,21 @@ export default function ContactInfoList(){
         <ul>
             <li key="phoneNumber">
                 <a href='tel:7329080037'>
-                    <FontAwesomeIcon icon={faPhone}/>
-                    &nbsp;+1(732)-908-0037
+                    <FontAwesomeIcon icon={faPhone} className='icon-md'/>
+                    <span>+1(732)-908-0037</span>
                 </a>
             </li>
             <li key='emailContact'>
                 <a href='mailto:jesse@piccione.dev'>
-                    <FontAwesomeIcon icon={faEnvelope}/>
-                    &nbsp;jesse@piccione.dev
+                    <FontAwesomeIcon icon={faEnvelope} className='icon-md'/>
+                    <span>jesse@piccione.dev</span>
                 </a>
             </li>
             <li key='location'>
                 <a href='https://maps.app.goo.gl/e11M1MzYEwu392vf7'>
                     <label htmlFor='locationIframe'>
-                        <FontAwesomeIcon icon={faLocationDot}/>
-                        &nbsp;Toms River, New Jersey
+                        <FontAwesomeIcon icon={faLocationDot} className='icon-md'/>
+                        <span>Toms River, New Jersey</span>
                     </label>
                 </a>
                 <iframe title='Toms River, New Jersey' id='locationIframe' src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d391236.70388095395!2d-74.49394522024458!3d39.99645668735483!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c19ce4a38e7105%3A0x3f5b6f5b358b3cb0!2sToms%20River%2C%20NJ!5e0!3m2!1sen!2sus!4v1740335442445!5m2!1sen!2sus" style={{"border":0}} loading="lazy" referrerPolicy="no-referrer-when-downgrade"></iframe>

--- a/src/components/postsmall.js
+++ b/src/components/postsmall.js
@@ -28,7 +28,7 @@ export default function Post({technologies, title, description, URL, ...props}){
                     <h3>{title}</h3>
                     <p>{description}</p>
                     <p onClick={handleClick}>
-                            {(postSize!=='big')?'See More':'See Less'} <FontAwesomeIcon icon={(postSize!=='big')?faAngleDown:faAngleUp} />
+                            {(postSize!=='big')?'See More':'See Less'} <FontAwesomeIcon icon={(postSize!=='big')?faAngleDown:faAngleUp} className='icon-md' />
                     </p>
                 </section>
             </article>

--- a/src/styles/partials/_icons.sass
+++ b/src/styles/partials/_icons.sass
@@ -1,7 +1,10 @@
+@use "variables"
+
 @mixin icon($size: 1rem, $color: currentColor)
   font-size: $size
   color: $color
   vertical-align: middle
+  margin-inline: calc(variables.$margin-half / 2)
 
 .icon-md
   @include icon(1rem)


### PR DESCRIPTION
## Summary
- apply `margin-inline` in icon mixin for spacing
- use `icon-md` class in ContactInfoList, PostSmall, and AIAssistant
- replace HTML entity spacing with spans for contact info

## Testing
- `npm run sass`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842023321348325adb960bf79f59916