### PR TITLE
Implement spin effect for theme toggle

### DIFF
--- a/src/components/themeToggle.js
+++ b/src/components/themeToggle.js
@@ -5,6 +5,7 @@ import { faSun, faMoon } from '@fortawesome/free-regular-svg-icons'
 
 export default function ThemeToggle({className = ''}){
     const [theme, setTheme] = useState('light')
+    const [spinning, setSpinning] = useState(false)
     useEffect(() => {
         const saved = typeof window !== 'undefined' ? localStorage.getItem('theme') : null
         const prefersDark = typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -14,6 +15,8 @@ export default function ThemeToggle({className = ''}){
     }, [])
 
     const toggleTheme = () => {
+        setSpinning(true)
+        setTimeout(() => setSpinning(false), 500)
         const newTheme = theme === 'dark' ? 'light' : 'dark'
         setTheme(newTheme)
         if (typeof document !== 'undefined') document.documentElement.classList.toggle('dark', newTheme === 'dark')
@@ -21,7 +24,11 @@ export default function ThemeToggle({className = ''}){
     }
 
     return (
-        <button className={`theme-toggle ${className}`} onClick={toggleTheme} aria-label='Toggle theme'>
+        <button
+            className={`theme-toggle ${className} ${spinning ? 'theme-toggle-spinning' : ''}`}
+            onClick={toggleTheme}
+            aria-label='Toggle theme'
+        >
             {theme === 'dark' ? (
                 <FontAwesomeIcon icon={faSun} className='icon-md' />
             ) : (

--- a/src/styles/partials/_base.sass
+++ b/src/styles/partials/_base.sass
@@ -125,7 +125,13 @@ li
     transition: transform 0.25s ease
     &:hover
         transform: scale(1.1)
-    &:active
+.theme-toggle-spinning
+    animation: rotate-theme 0.5s linear
+
+@keyframes rotate-theme
+    from
+        transform: rotate(0deg)
+    to
         transform: rotate(360deg)
 
 .floating-theme-toggle


### PR DESCRIPTION
## Summary
- add spinning state for ThemeToggle component
- trigger rotation animation via CSS class
- define rotate-theme keyframes for button spin

## Testing
- `npm run sass`
- `npm run lint`
- `npm run build` *(fails to fetch external posts but build finishes)*

------
https://chatgpt.com/codex/tasks/task_e_68422640c19c83258aef16829b3afd39