### PR TITLE
Ensure responsive layout on small screens

### DIFF
--- a/src/styles/partials/_base.sass
+++ b/src/styles/partials/_base.sass
@@ -4,6 +4,7 @@
 *
     margin: 0
     padding: 0
+    box-sizing: border-box
 
 ::-webkit-scrollbar
     display: none

--- a/src/styles/partials/_blog.sass
+++ b/src/styles/partials/_blog.sass
@@ -2,7 +2,7 @@
 
 // Blog section styles
 section.blog
-    width: 100vw
+    width: 100%
     display: flex
     position: static
     flex-flow: row wrap
@@ -20,7 +20,7 @@ section.blog
         flex-flow: column nowrap
         margin: variables.$margin
     ul
-        max-width: calc(100vw - variables.$margin-double)
+        max-width: calc(100% - variables.$margin-double)
         display: flex
         overflow-x: scroll
         overflow-y: visible
@@ -34,7 +34,7 @@ section.blog-post
         padding: 0
     
     > article
-        width: calc(100vw - variables.$margin-double)
+        width: calc(100% - variables.$margin-double)
         margin: variables.$margin variables.$margin variables.$margin 0
         padding-bottom: variables.$margin
         background: variables.$surface
@@ -102,7 +102,7 @@ section.blog-post.big
         z-index: 2
         margin: 0
         max-height: calc(100vh - variables.$margin-triple)
-        width: calc(100vw - variables.$margin-double)
+        width: calc(100% - variables.$margin-double)
         overflow: scroll
     
     p
@@ -111,7 +111,7 @@ section.blog-post.big
 // Blog post browser
 #BlogPostBrowser
     position: fixed
-    width: 100vw
+    width: 100%
     height: 100vh
     background: rgba(0,0,0,0.8)
     color: variables.$text

--- a/src/styles/partials/_header.sass
+++ b/src/styles/partials/_header.sass
@@ -2,7 +2,7 @@
 
 // Header styles
 header.Header
-    width: 100vw
+    width: 100%
     grid-area: head
     display: flex
     flex-flow: row nowrap

--- a/src/styles/partials/_modals.sass
+++ b/src/styles/partials/_modals.sass
@@ -4,7 +4,7 @@
 // Full Resume Modal
 section#fullResume
     position: fixed
-    width: 100vw
+    width: 100%
     height: 100vh
     background: rgba(0,0,0,0.8)
     color: variables.$text

--- a/src/styles/partials/_responsive.sass
+++ b/src/styles/partials/_responsive.sass
@@ -1,7 +1,7 @@
 @use "variables"
 //small mobile screen width 320px
 img
-    width: calc(100vw - (variables.$margin-double))
+    width: calc(100% - (variables.$margin-double))
     max-width: calc(600px - variables.$margin-double)
 
 // Responsive styles


### PR DESCRIPTION
## Summary
- apply `box-sizing: border-box` to all elements
- remove fixed `100vw` widths to prevent overflow on small screens
- keep images and modal widths responsive

## Testing
- `npm run lint`
- `npm run sass`
- `npm run build` *(fails to fetch some posts due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68422c02fd78832584ce3ea541fbefbd