### PR TITLE
Change secret path to BACKEND_API_TOKEN

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,5 +20,5 @@ steps:
     - BACKEND_API_TOKEN
 availableSecrets:
   secretManager:
-    - versionName: 'projects/piccione-dev/secrets/backend-api-token/versions/latest'
+    - versionName: 'projects/piccione-dev/secrets/BACKEND_API_TOKEN/versions/latest'
       env: 'BACKEND_API_TOKEN'


### PR DESCRIPTION
## Summary
- update cloudbuild secret path to use `BACKEND_API_TOKEN`

## Testing
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_68423416115083258420a50b5ff69216