### PR TITLE
Fix viewport for mobile

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -38,6 +38,11 @@ export const metadata = {
     appleTouchIconType: 'image/png',
     appleTouchIconRel: 'apple-touch-icon',
 }
+
+export const viewport = {
+    width: 'device-width',
+    initialScale: 1,
+}
 export default function RootLayout(props){
     return (
         <html lang='en' className={workSans.variable}>


### PR DESCRIPTION
## Summary
- add viewport metadata so mobile screens size correctly

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842367b834c8325be0fd046255ab614