### PR TITLE
Fix small-screen overflow

### DIFF
--- a/src/styles/partials/_ai-assistant.sass
+++ b/src/styles/partials/_ai-assistant.sass
@@ -17,7 +17,9 @@
   transition: all 0.3s ease
   overflow: hidden
   &.expanded
+    // Allow the panel to shrink on very small screens
     width: calc(variables.$small-width - variables.$margin-double)
+    max-width: 90vw
     height: 450px
   &-toggle
     width: 60px

--- a/src/styles/partials/_base.sass
+++ b/src/styles/partials/_base.sass
@@ -13,7 +13,7 @@ html
     scroll-behavior: smooth
 
 body
-    overflow-x: hidden
+    // Allow horizontal scrolling to reveal any layout issues
     width: 100%
     display: grid
     grid-template-areas: "nav" "head" "main" "foot"

--- a/src/styles/partials/_blog.sass
+++ b/src/styles/partials/_blog.sass
@@ -15,7 +15,8 @@ section.blog
     box-shadow: none
     
     > article
-        width: 100%
+        // Subtract horizontal margins from width to avoid overflow on small screens
+        width: calc(100% - variables.$margin-double)
         display: flex
         flex-flow: column nowrap
         margin: variables.$margin

--- a/src/styles/partials/_responsive.sass
+++ b/src/styles/partials/_responsive.sass
@@ -67,7 +67,8 @@ img
     section#fullResume > article, section.blog-post.big > article, #BlogPostBrowser > article
         width: calc(variables.$large-width - variables.$margin-double)
     section.eresume > article, section.blog > article, section.about > article, section.contact > article, footer.Footer > nav, #fullResume
-        width: variables.$large-width
+        // Account for horizontal margins so sections fit within the viewport
+        width: calc(variables.$large-width - variables.$margin-double)
     button.MenuToggle, section.menu-hamburger-container
         display: none
     footer.Footer
@@ -111,7 +112,8 @@ img
     section#fullResume > article, section.blog-post.big > article, #BlogPostBrowser > article
         width: calc(variables.$xl-width - variables.$margin-double)
     section.eresume > article, section.blog > article, section.about > article, section.contact > article, footer.Footer > nav, #fullResume
-        width: variables.$xl-width
+        // Account for horizontal margins so sections fit within the viewport
+        width: calc(variables.$xl-width - variables.$margin-double)
     img
         width: calc(425px - variables.$margin-double)
         max-width: none


### PR DESCRIPTION
## Summary
- prevent blog article from exceeding container width
- account for section margins at large and xl breakpoints
- make AI assistant panel responsive on tiny screens
- allow horizontal scroll for debugging

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68423efaef088325af69df697c8dbe3a