### PR TITLE
Remove About section hover effect

### DIFF
--- a/src/styles/partials/_main.sass
+++ b/src/styles/partials/_main.sass
@@ -69,6 +69,3 @@ section.about
     box-shadow: none
     > article
         margin: variables.$margin
-        transition: box-shadow 0.2s ease
-        &:hover
-            box-shadow: variables.$shadow


### PR DESCRIPTION
## Summary
- remove the box-shadow hover effect from the About Me section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684324abd2408325bb9134a04aad6d6b