### PR TITLE
Add metadataBase to layout

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -8,6 +8,7 @@ const workSans = Work_Sans({
 })
 
 export const metadata = {
+    metadataBase: new URL('https://piccione.dev'),
     title: 'Piccione Software Development',
     description: 'Jesse Piccione Development (piccione.dev) is the professional portfolio of Jesse Piccione, a skilled software engineer specializing in full-stack web development. This site showcases expertise in modern technologies such as Python, Django, JavaScript, and cloud platforms like Google Cloud. Featuring a dynamic e-resume, project highlights, and technical insights, piccione.dev demonstrates Jesse’s ability to craft innovative, user-focused solutions. Explore a blend of creativity and technical proficiency designed to connect with clients, employers, and fellow developers.',
     keywords: 'software development, web development, full-stack development, python, django, javascript, google cloud, portfolio',


### PR DESCRIPTION
## Summary
- add `metadataBase` property in app layout metadata

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eba2ff3408325966d322407a9f559