### PR TITLE
Remove unused toggleDrawer

### DIFF
--- a/src/components/providers/fullresumestate.js
+++ b/src/components/providers/fullresumestate.js
@@ -12,16 +12,4 @@ export default function FullResumeState({children}){
     )
 }
 
-function toggleDrawer(previousState){
-    switch (previousState) {
-        case 'open':
-            return 'opened'
-        case 'opened':
-            return 'close'
-        case 'close':
-            return 'closed'
-        case 'closed':
-            return 'open'
-    }
-}
 export const ResumeState = () => useContext(FullResumeStateContext)


### PR DESCRIPTION
## Summary
- remove the unused `toggleDrawer` function in `fullresumestate.js`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685eba31cad88325a5870f1c6755f073