### PR TITLE
Use backend URL env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ This repository contains the source code for [piccione.dev](https://piccione.dev
    ```bash
    npm install
    ```
+
 2. Build the project:
    ```bash
    npm run build
    ```
+
+### Environment Variables
+
+Set `NEXT_PUBLIC_BACKEND_URL` to override the default backend API base URL (`https://portal.piccione.dev`).
 
 ## Running Locally
 

--- a/src/components/api/formMessage.js
+++ b/src/components/api/formMessage.js
@@ -9,8 +9,9 @@ export default async function formMessage({name, phone, message, email, subject}
             "subject": subject,
             "message": message
         }
+        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'https://portal.piccione.dev'
         await fetch(
-            'https://portal.piccione.dev/api/message/',
+            `${backendUrl}/api/message/`,
             {
                 method:'POST',
                 headers:{

--- a/src/components/api/getAssistantResponse.js
+++ b/src/components/api/getAssistantResponse.js
@@ -2,7 +2,8 @@
 export default async function getAssistantResponse(message){
     try{
         const token = process.env.BACKEND_API_TOKEN
-        const res = await fetch('https://portal.piccione.dev/api/assistant/', {
+        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'https://portal.piccione.dev'
+        const res = await fetch(`${backendUrl}/api/assistant/`, {
             method: 'POST',
             headers: {
                 'Authorization': `Bearer ${token}`,

--- a/src/components/api/getData.js
+++ b/src/components/api/getData.js
@@ -1,7 +1,8 @@
 'use server'
 export default async function getData(endpoint){
     try{
-        const req = await fetch(`https://portal.piccione.dev/${endpoint}`,{
+        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'https://portal.piccione.dev'
+        const req = await fetch(`${backendUrl}/${endpoint}`,{
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json',

--- a/src/components/blog.js
+++ b/src/components/blog.js
@@ -1,10 +1,11 @@
 import Post from '@/components/postsmall'
 import OpenPostBrowserButton from '@/components/postbrowser/openpostbrowserbutton'
 import Reveal from '@/components/reveal'
+const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'https://portal.piccione.dev'
 export default async function Blog(){
     let posts = []
     try {
-        const res = await fetch('https://portal.piccione.dev/api/home/')
+        const res = await fetch(`${backendUrl}/api/home/`)
         posts = await res.json()
     } catch (err) {
         console.error('Blog: failed to fetch posts', err)

--- a/src/components/navlist.js
+++ b/src/components/navlist.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faHouse, faFileLines, faBlog, faUser, faEnvelope, faRightToBracket, faCircleDollarToSlot } from '@fortawesome/free-solid-svg-icons'
 
+const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'https://portal.piccione.dev'
+
 const NavList = React.forwardRef(function NavList(props, ref){
     return (
         <ul ref={ref} {...props}>
@@ -36,7 +38,7 @@ const NavList = React.forwardRef(function NavList(props, ref){
                 </a>
             </li>
             <li>
-                <a href='https://portal.piccione.dev/admin/'>
+                <a href={`${backendUrl}/admin/`}>
                     <FontAwesomeIcon icon={faRightToBracket} className='icon-md' />
                     <span>Portal</span>
                 </a>


### PR DESCRIPTION
## Summary
- centralize backend url with `NEXT_PUBLIC_BACKEND_URL`
- update all API utilities/components to use the variable
- document the environment variable in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eba33a9b083258d791e95088c4ecb