### PR TITLE
Update docs for backend variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ This repository contains the source code for [piccione.dev](https://piccione.dev
    npm run build
    ```
 
+## Environment Variables
+
+The application communicates with a backend service and requires a token for authentication. Configure the following variables when running or deploying the site:
+
+- `BACKEND_API_TOKEN` – Bearer token used to authorize requests to the backend APIs.
+- `BACKEND_BASE_URL` – Base URL for the backend service. Defaults to `https://portal.piccione.dev`.
+
+Example for local development:
+
+```bash
+BACKEND_API_TOKEN=<token> BACKEND_BASE_URL=https://portal.piccione.dev npm run dev
+```
+
+When deploying, set `BACKEND_API_TOKEN` as a secret or environment variable and provide `BACKEND_BASE_URL` if a custom backend is used.
+
 ## Running Locally
 
 During development you can start the development server with:
@@ -33,7 +48,10 @@ The application listens on port `3000` by default.
 A `Dockerfile` is provided to build a production image. Build and run the container locally with:
 ```bash
 docker build -t website .
-docker run -p 3000:3000 website
+docker run -p 3000:3000 \
+  -e BACKEND_API_TOKEN=<token> \
+  -e BACKEND_BASE_URL=https://portal.piccione.dev \
+  website
 ```
 
 ### Cloud Build
@@ -42,3 +60,5 @@ The `cloudbuild.yaml` file defines steps to build the Docker image, push it to G
 ```bash
 gcloud builds submit --config cloudbuild.yaml
 ```
+The build uses Secret Manager to inject `BACKEND_API_TOKEN`. Set `BACKEND_BASE_URL`
+as an additional environment variable if you deploy against a custom backend.


### PR DESCRIPTION
## Summary
- document `BACKEND_API_TOKEN`
- add `BACKEND_BASE_URL` env var docs
- show how to pass env vars when running in Docker and Cloud Build

## Testing
- `npm test --silent`
- `npm run build --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685eba3531648325a97d4c7a98943701