### PR TITLE
Add production environment variable in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM node
 WORKDIR /app
+ENV NODE_ENV=production
 COPY package*.json ./
 RUN npm install
 COPY . .
 RUN npm run build
 EXPOSE 3000
-ENTRYPOINT ["npm", "start"]
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- set `NODE_ENV` to production in Dockerfile
- switch to `CMD` for easier override

## Testing
- `npm test`
- `docker build -t website .` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_685eba3af7a08325865699cec0911514