### PR TITLE
Add Google Adsense verification

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-1851572737165261, DIRECT, f08c47fec0942fa0

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,4 +1,5 @@
 import { Work_Sans } from 'next/font/google'
+import Script from 'next/script'
 import ThemeToggle from '@/components/themeToggle'
 
 const workSans = Work_Sans({
@@ -38,6 +39,9 @@ export const metadata = {
     appleTouchIconSizes: '180x180',
     appleTouchIconType: 'image/png',
     appleTouchIconRel: 'apple-touch-icon',
+    other: {
+        'google-adsense-account': 'ca-pub-1851572737165261',
+    },
 }
 export default function RootLayout(props){
     return (
@@ -45,6 +49,11 @@ export default function RootLayout(props){
             <body>
                 {props.children}
                 <ThemeToggle className='floating-theme-toggle'/>
+                <Script
+                    async
+                    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1851572737165261"
+                    crossOrigin="anonymous"
+                />
             </body>
         </html>
     )


### PR DESCRIPTION
## Summary
- add ads.txt for Google Adsense verification
- inject Adsense meta tag and script in root layout
- enable crawling with robots.txt

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d535a99b083259973067b0a89c39b