### PR TITLE
feat: add admin dashboard

### DIFF
--- a/__tests__/adminDashboard.test.js
+++ b/__tests__/adminDashboard.test.js
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import NavList from '@/components/navlist'
+import AdminPage from '@/app/admin/page'
+import { UserContext } from '@/components/providers/user'
+
+describe('admin navigation link', () => {
+  it('shows link for admin', () => {
+    render(
+      <UserContext.Provider value={{ role: 'admin' }}>
+        <NavList />
+      </UserContext.Provider>
+    )
+    expect(screen.getByText('Admin')).toBeInTheDocument()
+  })
+
+  it('hides link for non-admin', () => {
+    render(
+      <UserContext.Provider value={{ role: 'user' }}>
+        <NavList />
+      </UserContext.Provider>
+    )
+    expect(screen.queryByText('Admin')).toBeNull()
+  })
+})
+
+describe('admin page access', () => {
+  beforeEach(() => {
+    fetch.resetMocks()
+  })
+
+  it('denies access to non-admin', () => {
+    render(
+      <UserContext.Provider value={{ role: 'user' }}>
+        <AdminPage />
+      </UserContext.Provider>
+    )
+    expect(screen.getByText('Access Denied')).toBeInTheDocument()
+  })
+
+  it('shows user table and counts for admin', async () => {
+    const users = [
+      { id: 1, name: 'Alice', status: 'Pending', lastActivity: '2024-01-01' },
+      { id: 2, name: 'Bob', status: 'Approved', lastActivity: '2024-01-02' },
+      { id: 3, name: 'Carol', status: 'Posted', lastActivity: '2024-01-03' },
+      { id: 4, name: 'Dave', status: 'Denied', lastActivity: '2024-01-04' }
+    ]
+    fetch.mockResponseOnce(JSON.stringify(users))
+    render(
+      <UserContext.Provider value={{ role: 'admin' }}>
+        <AdminPage />
+      </UserContext.Provider>
+    )
+    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument())
+    expect(screen.getByText('Pending: 1')).toBeInTheDocument()
+    expect(screen.getByText('Approved: 1')).toBeInTheDocument()
+    expect(screen.getByText('Posted: 1')).toBeInTheDocument()
+    expect(screen.getByText('Denied: 1')).toBeInTheDocument()
+  })
+})

--- a/src/app/admin/page.js
+++ b/src/app/admin/page.js
@@ -1,0 +1,66 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { useUser } from '@/components/providers/user'
+
+export default function AdminPage() {
+    const user = useUser()
+    const [users, setUsers] = useState([])
+    const [counts, setCounts] = useState({ Pending: 0, Approved: 0, Posted: 0, Denied: 0 })
+
+    useEffect(() => {
+        if (user?.role !== 'admin') return
+        async function fetchUsers() {
+            try {
+                const res = await fetch('/api/users')
+                if (res.ok) {
+                    const data = await res.json()
+                    setUsers(data)
+                    const newCounts = { Pending: 0, Approved: 0, Posted: 0, Denied: 0 }
+                    data.forEach(u => {
+                        const status = u.status
+                        if (status && newCounts.hasOwnProperty(status)) {
+                            newCounts[status] += 1
+                        }
+                    })
+                    setCounts(newCounts)
+                }
+            } catch (err) {
+                // ignore errors
+            }
+        }
+        fetchUsers()
+    }, [user])
+
+    if (!user) return null
+    if (user.role !== 'admin') return <p>Access Denied</p>
+
+    return (
+        <main>
+            <h1>Admin Dashboard</h1>
+            <div>
+                <p>Pending: {counts.Pending}</p>
+                <p>Approved: {counts.Approved}</p>
+                <p>Posted: {counts.Posted}</p>
+                <p>Denied: {counts.Denied}</p>
+            </div>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Status</th>
+                        <th>Last Activity</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {users.map(u => (
+                        <tr key={u.id}>
+                            <td>{u.name}</td>
+                            <td>{u.status}</td>
+                            <td>{u.lastActivity}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </main>
+    )
+}

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,6 +1,7 @@
 import { Work_Sans } from 'next/font/google'
 import Script from 'next/script'
 import ThemeToggle from '@/components/themeToggle'
+import { UserProvider } from '@/components/providers/user'
 
 const workSans = Work_Sans({
     weight: ['400', '600', '800'],
@@ -47,8 +48,10 @@ export default function RootLayout(props){
     return (
         <html lang='en' className={workSans.variable}>
             <body>
-                {props.children}
-                <ThemeToggle className='floating-theme-toggle'/>
+                <UserProvider>
+                    {props.children}
+                    <ThemeToggle className='floating-theme-toggle'/>
+                </UserProvider>
                 <Script
                     async
                     src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1851572737165261"

--- a/src/components/navlist.js
+++ b/src/components/navlist.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faHouse, faFileLines, faBlog, faUser, faEnvelope, faRightToBracket, faCircleDollarToSlot } from '@fortawesome/free-solid-svg-icons'
-
-const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'https://portal.piccione.dev'
+import { useUser } from './providers/user'
 
 const NavList = React.forwardRef(function NavList(props, ref){
+    const user = useUser()
     return (
         <ul ref={ref} {...props}>
             <li>
@@ -37,12 +37,14 @@ const NavList = React.forwardRef(function NavList(props, ref){
                     <span>Contact</span>
                 </a>
             </li>
-            <li>
-                <a href={`${backendUrl}/admin/`}>
-                    <FontAwesomeIcon icon={faRightToBracket} className='icon-md' />
-                    <span>Portal</span>
-                </a>
-            </li>
+            {user?.role === 'admin' && (
+                <li>
+                    <a href='/admin'>
+                        <FontAwesomeIcon icon={faRightToBracket} className='icon-md' />
+                        <span>Admin</span>
+                    </a>
+                </li>
+            )}
             <li>
                 <a href='https://www.paypal.com/donate/?hosted_button_id=8QNED3VCSZHYG'>
                     <FontAwesomeIcon icon={faCircleDollarToSlot} className='icon-md' />

--- a/src/components/providers/user.js
+++ b/src/components/providers/user.js
@@ -1,0 +1,29 @@
+"use client"
+import { createContext, useContext, useEffect, useState } from 'react'
+
+export const UserContext = createContext(null)
+
+export function UserProvider({ children }) {
+    const [user, setUser] = useState(null)
+    useEffect(() => {
+        async function fetchUser() {
+            try {
+                const res = await fetch('/api/users/me')
+                if (res.ok) {
+                    const data = await res.json()
+                    setUser(data)
+                }
+            } catch (err) {
+                // ignore errors
+            }
+        }
+        fetchUser()
+    }, [])
+    return (
+        <UserContext.Provider value={user}>
+            {children}
+        </UserContext.Provider>
+    )
+}
+
+export const useUser = () => useContext(UserContext)


### PR DESCRIPTION
## Summary
- add user context and provider
- add admin dashboard page listing users and status counts
- show admin link in nav only for admin role
- ensure non-admins denied and covered by tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896a6b5c9ac8325b10bc0ffcbfa36da